### PR TITLE
fix: correct CI badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Bowerbird Githooks
 
-[![Makefile CI](https://github.com/asikros/make-bowerbird-git/actions/workflows/makefile.yml/badge.svg)](https://github.com/asikros/make-bowerbird-git/actions/workflows/makefile.yml)
+[![Makefile CI](https://github.com/asikros/make-bowerbird-githooks/actions/workflows/makefile.yml/badge.svg)](https://github.com/asikros/make-bowerbird-githooks/actions/workflows/makefile.yml)


### PR DESCRIPTION
- Update badge URL from make-bowerbird-git to make-bowerbird-githooks